### PR TITLE
feat: add express REST API for produtos

### DIFF
--- a/mongoDB/04_intro_v4/.gitignore
+++ b/mongoDB/04_intro_v4/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/mongoDB/04_intro_v4/app.js
+++ b/mongoDB/04_intro_v4/app.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+
+const produtoRoutes = require('./routes/produtoRoutes');
+
+dotenv.config();
+
+const app = express();
+
+app.use(express.json());
+app.use('/produtos', produtoRoutes);
+
+const PORT = process.env.PORT || 3000;
+
+mongoose
+  .connect(process.env.MONGO_URI)
+  .then(() => {
+    console.log('🟢 Conectado ao MongoDB');
+    app.listen(PORT, () => {
+      console.log(`🚀 Servidor rodando na porta ${PORT}`);
+    });
+  })
+  .catch((err) => {
+    console.error('Erro ao conectar ao MongoDB:', err.message);
+  });
+
+module.exports = app;
+

--- a/mongoDB/04_intro_v4/controllers/produtoController.js
+++ b/mongoDB/04_intro_v4/controllers/produtoController.js
@@ -1,0 +1,35 @@
+const {
+  criar,
+  listar,
+  buscarPorId,
+  atualizar,
+  deletar
+} = require('../services/produtoService');
+
+async function criarProduto(dados) {
+  return await criar(dados);
+}
+
+async function listarProdutos() {
+  return await listar();
+}
+
+async function buscarProdutoPorId(id) {
+  return await buscarPorId(id);
+}
+
+async function atualizarProduto(id, novosDados) {
+  return await atualizar(id, novosDados);
+}
+
+async function deletarProduto(id) {
+  return await deletar(id);
+}
+
+module.exports = {
+  criarProduto,
+  listarProdutos,
+  buscarProdutoPorId,
+  atualizarProduto,
+  deletarProduto
+};

--- a/mongoDB/04_intro_v4/index.js
+++ b/mongoDB/04_intro_v4/index.js
@@ -1,0 +1,2 @@
+// index.js
+require('./app');

--- a/mongoDB/04_intro_v4/models/produtoModel.js
+++ b/mongoDB/04_intro_v4/models/produtoModel.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+const ProdutoSchema = new mongoose.Schema({
+  produto: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  preco: {
+    type: Number,
+    required: true,
+    min: 0
+  },
+  unidade: {
+    type: String,
+    enum: ['kg', 'saca', 'tonelada'],
+    required: true
+  },
+  peso: {
+    type: Number,
+    required: true,
+    min: 0
+  }
+}, {
+  timestamps: true
+});
+
+module.exports = mongoose.model('Produto', ProdutoSchema);

--- a/mongoDB/04_intro_v4/package-lock.json
+++ b/mongoDB/04_intro_v4/package-lock.json
@@ -1,0 +1,257 @@
+{
+  "name": "03_intro_v3",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "03_intro_v3",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^17.2.1",
+        "mongoose": "^8.17.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
+      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
+      "integrity": "sha512-fO5ttN9VC8P0F5fqtQmclAkgXZxbIkYRTUi1j8JO6IYwvamkhtYDilJr35jOPELR49zqCJgXZWwCtW7B+TM8vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.0.tgz",
+      "integrity": "sha512-mxW6TBPHViORfNYOFXCVOnT4d5aRr+CgDxTs1ViYXfuHzNpkelgJQrQa+Lz6hofoEQISnKlXv1L3ZnHyJRkhfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.18.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/mongoDB/04_intro_v4/package.json
+++ b/mongoDB/04_intro_v4/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "04_intro_v4",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "dotenv": "^17.2.1",
+    "express": "^4.19.2",
+    "mongoose": "^8.17.0"
+  }
+}

--- a/mongoDB/04_intro_v4/readme.md
+++ b/mongoDB/04_intro_v4/readme.md
@@ -1,0 +1,76 @@
+# 📦 Projeto 04_intro_v4 – API REST com Express e Mongoose
+
+Esta versão evolui o exemplo anterior para uma API REST completa usando **Express** e mantendo a arquitetura em camadas.
+
+---
+
+## 🚀 Como instalar
+
+```bash
+git clone <url-do-repositorio>
+cd mongoDB/04_intro_v4
+npm install
+```
+
+Crie um arquivo `.env` com a string de conexão do MongoDB e, opcionalmente, a porta do servidor:
+
+```
+MONGO_URI=mongodb://<usuario>:<senha>@<host>/<banco>
+PORT=3000
+```
+
+---
+
+## ▶️ Como iniciar o projeto
+
+```bash
+npm start
+```
+
+---
+
+## 📚 Endpoints
+
+| Método | Rota              | Descrição                       |
+|--------|------------------|--------------------------------|
+| GET    | `/produtos`       | Lista todos os produtos        |
+| GET    | `/produtos/:id`   | Busca produto pelo ID          |
+| POST   | `/produtos`       | Cria um novo produto           |
+| PUT    | `/produtos/:id`   | Atualiza um produto existente  |
+| DELETE | `/produtos/:id`   | Remove um produto              |
+
+### Exemplo de corpo para POST/PUT
+
+```json
+{
+  "produto": "Café",
+  "preco": 32.5,
+  "unidade": "kg",
+  "peso": 5
+}
+```
+
+---
+
+## 🧠 Arquitetura do Projeto
+
+```
+04_intro_v4/
+│
+├── app.js                 # Configuração do Express e da conexão com o MongoDB
+├── index.js               # Ponto de entrada
+├── routes/                # Definição das rotas
+├── controllers/           # Camada de controle
+├── services/              # Regras de negócio
+└── models/                # Schemas do Mongoose
+```
+
+---
+
+## 🛠 Tecnologias
+
+- Node.js
+- Express
+- Mongoose
+- MongoDB
+

--- a/mongoDB/04_intro_v4/routes/produtoRoutes.js
+++ b/mongoDB/04_intro_v4/routes/produtoRoutes.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const {
+  criarProduto,
+  listarProdutos,
+  buscarProdutoPorId,
+  atualizarProduto,
+  deletarProduto
+} = require('../controllers/produtoController');
+
+const router = express.Router();
+
+// GET /produtos
+router.get('/', async (req, res) => {
+  try {
+    const produtos = await listarProdutos();
+    res.json(produtos);
+  } catch (err) {
+    res.status(500).json({ erro: err.message });
+  }
+});
+
+// GET /produtos/:id
+router.get('/:id', async (req, res) => {
+  try {
+    const produto = await buscarProdutoPorId(req.params.id);
+    if (!produto) {
+      return res.status(404).json({ mensagem: 'Produto não encontrado' });
+    }
+    res.json(produto);
+  } catch (err) {
+    res.status(500).json({ erro: err.message });
+  }
+});
+
+// POST /produtos
+router.post('/', async (req, res) => {
+  try {
+    const novoProduto = await criarProduto(req.body);
+    res.status(201).json(novoProduto);
+  } catch (err) {
+    res.status(500).json({ erro: err.message });
+  }
+});
+
+// PUT /produtos/:id
+router.put('/:id', async (req, res) => {
+  try {
+    const produtoAtualizado = await atualizarProduto(req.params.id, req.body);
+    if (!produtoAtualizado) {
+      return res.status(404).json({ mensagem: 'Produto não encontrado' });
+    }
+    res.json(produtoAtualizado);
+  } catch (err) {
+    res.status(500).json({ erro: err.message });
+  }
+});
+
+// DELETE /produtos/:id
+router.delete('/:id', async (req, res) => {
+  try {
+    const produtoDeletado = await deletarProduto(req.params.id);
+    if (!produtoDeletado) {
+      return res.status(404).json({ mensagem: 'Produto não encontrado' });
+    }
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ erro: err.message });
+  }
+});
+
+module.exports = router;
+

--- a/mongoDB/04_intro_v4/services/produtoService.js
+++ b/mongoDB/04_intro_v4/services/produtoService.js
@@ -1,0 +1,30 @@
+const Produto = require('../models/produtoModel');
+
+async function criar(dados) {
+  const novoProduto = new Produto(dados);
+  return await novoProduto.save();
+}
+
+async function listar() {
+  return await Produto.find();
+}
+
+async function buscarPorId(id) {
+  return await Produto.findById(id);
+}
+
+async function atualizar(id, novosDados) {
+  return await Produto.findByIdAndUpdate(id, novosDados, { new: true });
+}
+
+async function deletar(id) {
+  return await Produto.findByIdAndDelete(id);
+}
+
+module.exports = {
+  criar,
+  listar,
+  buscarPorId,
+  atualizar,
+  deletar
+};


### PR DESCRIPTION
## Summary
- copy v3 example into new v4 folder and transition to REST API
- register product routes and configure Express app with MongoDB connection
- document usage and endpoints in README

## Testing
- `npm test`
- `npm install express` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_689225d413708332ad09ab02933296ad